### PR TITLE
fix(ng2-version): support ng 2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,15 +43,15 @@
   },
   "homepage": "https://github.com/hboylan/ng2-http#readme",
   "devDependencies": {
-    "@angular/common": "~2.1.2",
-    "@angular/compiler": "~2.1.2",
-    "@angular/compiler-cli": "~2.1.2",
-    "@angular/core": "~2.1.2",
-    "@angular/forms": "~2.1.2",
-    "@angular/http": "~2.1.2",
-    "@angular/platform-browser": "~2.1.2",
-    "@angular/platform-browser-dynamic": "~2.1.2",
-    "@angular/platform-server": "~2.1.2",
+    "@angular/common": "^2.1.2",
+    "@angular/compiler": "^2.1.2",
+    "@angular/compiler-cli": "^2.1.2",
+    "@angular/core": "^2.1.2",
+    "@angular/forms": "^2.1.2",
+    "@angular/http": "^2.1.2",
+    "@angular/platform-browser": "^2.1.2",
+    "@angular/platform-browser-dynamic": "^2.1.2",
+    "@angular/platform-server": "^2.1.2",
     "@types/chai": "~3.4.34",
     "@types/core-js": "~0.9.34",
     "@types/jasmine": "~2.5.37",
@@ -91,8 +91,8 @@
     "zone.js": "~0.6.26"
   },
   "peerDependencies": {
-    "@angular/core": "~2.1.2",
-    "@angular/http": "~2.1.2"
+    "@angular/core": "^2.1.2",
+    "@angular/http": "^2.1.2"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Set the dependency to be major version 2.* instead of minor version 2.1.*

no breaking changes, tests run correctly.