### PR TITLE
fix: only encode body as JSON for content-type application/json

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -89,13 +89,13 @@ export function method(method: number) {
         }
 
         // Body
-        var urlencoded = headers.get('Content-Type');
+        var contentType = headers.get('Content-Type');
         var body = null;
         if (pBody) {
-          if (urlencoded && urlencoded === 'application/x-www-form-urlencoded') {
-            body = args[pBody[0].parameterIndex];
-          } else {
+          if (contentType && contentType === 'application/json') {
             body = JSON.stringify(args[pBody[0].parameterIndex]);
+          } else {
+            body = args[pBody[0].parameterIndex];
           }
         }
 


### PR DESCRIPTION
`application/x-www-form-urlencoded` isn't the only case where you don't want to encode the body as JSON. Just think about cases like `text/plain` etc. 

So I switched the logic to only encode request bodies with content-type `application/json`